### PR TITLE
Logarithmic volume control

### DIFF
--- a/BlackHole/BlackHole.c
+++ b/BlackHole/BlackHole.c
@@ -16,6 +16,33 @@
 #include "BlackHole.h"
 
 
+// Volume conversions
+
+static Float32 volume_to_scalar(Float32 volume)
+{
+	return powf(volume, 1.0 / kVolume_Curve);
+}
+
+static Float32 volume_from_scalar(Float32 scalar)
+{
+	return powf(scalar, kVolume_Curve);
+}
+
+static Float32 volume_to_decibel(Float32 volume)
+{
+	if (volume <= powf(10.0f, kVolume_MinDB / 20.0f))
+		return kVolume_MinDB;
+	else
+		return 20.0f * log10f(volume);
+}
+
+static Float32 volume_from_decibel(Float32 decibel)
+{
+	if (decibel <= kVolume_MinDB)
+		return 0.0f;
+	else
+		return powf(10.0f, decibel / 20.0f);
+}
 
 
 #pragma mark Factory
@@ -3171,7 +3198,7 @@ static OSStatus	BlackHole_GetControlPropertyData(AudioServerPlugInDriverRef inDr
 					//	Note that we need to take the state lock to examine the value.
 					FailWithAction(inDataSize < sizeof(Float32), theAnswer = kAudioHardwareBadPropertySizeError, Done, "BlackHole_GetControlPropertyData: not enough space for the return value of kAudioLevelControlPropertyScalarValue for the volume control");
 					pthread_mutex_lock(&gPlugIn_StateMutex);
-					*((Float32*)outData) = (inObjectID == kObjectID_Volume_Input_Master) ? gVolume_Input_Master_Value : gVolume_Output_Master_Value;
+					*((Float32*)outData) = volume_to_scalar((inObjectID == kObjectID_Volume_Input_Master) ? gVolume_Input_Master_Value : gVolume_Output_Master_Value);
 					pthread_mutex_unlock(&gPlugIn_StateMutex);
 					*outDataSize = sizeof(Float32);
 					break;
@@ -3183,11 +3210,7 @@ static OSStatus	BlackHole_GetControlPropertyData(AudioServerPlugInDriverRef inDr
 					pthread_mutex_lock(&gPlugIn_StateMutex);
 					*((Float32*)outData) = (inObjectID == kObjectID_Volume_Input_Master) ? gVolume_Input_Master_Value : gVolume_Output_Master_Value;
 					pthread_mutex_unlock(&gPlugIn_StateMutex);
-					
-					//	Note that we square the scalar value before converting to dB so as to
-					//	provide a better curve for the slider
-					*((Float32*)outData) *= *((Float32*)outData);
-					*((Float32*)outData) = kVolume_MinDB + (*((Float32*)outData) * (kVolume_MaxDB - kVolume_MinDB));
+					*((Float32*)outData) = volume_to_decibel(*((Float32*)outData));
 					
 					//	report how much we wrote
 					*outDataSize = sizeof(Float32);
@@ -3447,7 +3470,7 @@ static OSStatus	BlackHole_SetControlPropertyData(AudioServerPlugInDriverRef inDr
 					//	For the scalar volume, we clamp the new value to [0, 1]. Note that if this
 					//	value changes, it implies that the dB value changed too.
 					FailWithAction(inDataSize != sizeof(Float32), theAnswer = kAudioHardwareBadPropertySizeError, Done, "BlackHole_SetControlPropertyData: wrong size for the data for kAudioLevelControlPropertyScalarValue");
-					theNewVolume = *((const Float32*)inData);
+					theNewVolume = volume_from_scalar(*((const Float32*)inData));
 					if(theNewVolume < 0.0)
 					{
 						theNewVolume = 0.0;
@@ -3502,11 +3525,7 @@ static OSStatus	BlackHole_SetControlPropertyData(AudioServerPlugInDriverRef inDr
 					{
 						theNewVolume = kVolume_MaxDB;
 					}
-					//	Note that we square the scalar value before converting to dB so as to
-					//	provide a better curve for the slider. We undo that here.
-					theNewVolume = theNewVolume - kVolume_MinDB;
-					theNewVolume /= kVolume_MaxDB - kVolume_MinDB;
-					theNewVolume = sqrtf(theNewVolume);
+					theNewVolume = volume_from_decibel(theNewVolume);
 					pthread_mutex_lock(&gPlugIn_StateMutex);
 					if(inObjectID == kObjectID_Volume_Input_Master)
 					{

--- a/BlackHole/BlackHole.c
+++ b/BlackHole/BlackHole.c
@@ -18,16 +18,6 @@
 
 // Volume conversions
 
-static Float32 volume_to_scalar(Float32 volume)
-{
-	return powf(volume, 1.0 / kVolume_Curve);
-}
-
-static Float32 volume_from_scalar(Float32 scalar)
-{
-	return powf(scalar, kVolume_Curve);
-}
-
 static Float32 volume_to_decibel(Float32 volume)
 {
 	if (volume <= powf(10.0f, kVolume_MinDB / 20.0f))
@@ -42,6 +32,18 @@ static Float32 volume_from_decibel(Float32 decibel)
 		return 0.0f;
 	else
 		return powf(10.0f, decibel / 20.0f);
+}
+
+static Float32 volume_to_scalar(Float32 volume)
+{
+	Float32 decibel = volume_to_decibel(volume);
+	return (decibel - kVolume_MinDB) / (kVolume_MaxDB - kVolume_MinDB);
+}
+
+static Float32 volume_from_scalar(Float32 scalar)
+{
+	Float32 decibel = scalar * (kVolume_MaxDB - kVolume_MinDB) + kVolume_MinDB;
+	return volume_from_decibel(decibel);
 }
 
 

--- a/BlackHole/BlackHole.h
+++ b/BlackHole/BlackHole.h
@@ -143,6 +143,7 @@ static bool                         gStream_Output_IsActive             = true;
 
 static const Float32                kVolume_MinDB                       = -96.0;
 static const Float32                kVolume_MaxDB                       = 0.0;
+static const Float32                kVolume_Curve                       = 4.0;
 static Float32                      gVolume_Input_Master_Value          = 1.0;
 static Float32                      gVolume_Output_Master_Value         = 1.0;
 

--- a/BlackHole/BlackHole.h
+++ b/BlackHole/BlackHole.h
@@ -141,9 +141,8 @@ static UInt64                       gDevice_AnchorHostTime              = 0;
 static bool                         gStream_Input_IsActive              = true;
 static bool                         gStream_Output_IsActive             = true;
 
-static const Float32                kVolume_MinDB                       = -96.0;
+static const Float32                kVolume_MinDB                       = -64.0;
 static const Float32                kVolume_MaxDB                       = 0.0;
-static const Float32                kVolume_Curve                       = 4.0;
 static Float32                      gVolume_Input_Master_Value          = 1.0;
 static Float32                      gVolume_Output_Master_Value         = 1.0;
 


### PR DESCRIPTION
Issue #149

Implementation of true logarithmic volume control.

Minimal dB value is changed to -64, since -96 makes control too coarse.
I think -64dB is reasonable because it's used in most built-in sound outputs and consumer-class DACs I tried.