### PR TITLE
Fix ringbuffer calloc count

### DIFF
--- a/BlackHole/BlackHole.c
+++ b/BlackHole/BlackHole.c
@@ -3581,7 +3581,7 @@ static OSStatus	BlackHole_StartIO(AudioServerPlugInDriverRef inDriver, AudioObje
 		gDevice_AnchorHostTime = mach_absolute_time();
         
         // allocate ring buffer
-        gRingBuffer = calloc(kRing_Buffer_Frame_Size * kNumber_Of_Channels, sizeof(Float32));
+        gRingBuffer = calloc(kDevice_RingBufferSize * kNumber_Of_Channels, sizeof(Float32));
 	}
 	else
 	{


### PR DESCRIPTION
Previously the ring buffer `calloc` call was allocating `kDevice_RingBufferSize * kBytes_Per_Channel * kNumber_Of_Channels * sizeof(Float32)` bytes, resulting in `gRingBuffer` being 4 times larger than necessary (`kBytes_Per_Channel` and `sizeof(Float32)` are redundant).  

The `calloc` call now uses the correct `kDevice_RingBufferSize * kNumber_Of_Channels` count.  This no longer takes `kLatency_Frame_Size` into account, but `kLatency_Frame_Size` is 0 and unused.