### PR TITLE
Add Java guide in BlackHole readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Visit the [Wiki](https://github.com/ExistentialAudio/BlackHole/wiki#advanced-cus
 ### Reaper
 - Reaper to Zoom by Noah Liebman (https://noahliebman.net/2020/12/telephone-colophon-or-how-i-overengineered-my-call-audio/)
 
+### Java
+- Capture microphone and audio file input to BlackHole and use in any voice chat application to act as a soundboard (https://github.com/sethmachine/universal-sound-board)
+
 ### Record System Audio
 1. [Setup Multi-output Device](https://github.com/ExistentialAudio/BlackHole/wiki/Multi-Output-Device)
 2. In `Audio Midi Setup`->`Audio Devices` Right-click on the newly created Multi-output and select "Use This Device For Sound Output"


### PR DESCRIPTION
Hi, I made a Java based soundboard app that uses virtual audio devices like BlackHole in order to route both microphone and audio file into a single voice input for apps like Discord and Zoom.  

I wrote the Java based software because I wanted to programmatically control soundboard functionality without having to go through existing GUIs.  

My guide is detailed and explains how one might use a virtual audio device like BlackHole for use in Java/a programmatic soundboard.  I reference BlackHole here (and use it for my soundboard on macOS): https://github.com/sethmachine/universal-sound-board#macos

GitHub repo: https://github.com/sethmachine/universal-sound-board

I was wondering if this could be included in the Guides section as a Java example of how to use BlackHole.  