### PR TITLE
Modify installer to build 4 of each driver.

### DIFF
--- a/Installer/create_installer.sh
+++ b/Installer/create_installer.sh
@@ -32,99 +32,105 @@ if [ -z "$version" ]; then
 fi
 
 for channels in 2 16 64 128 256; do
-    # Env
-    ch=$channels"ch"
-    driverVartiantName=$driverName$ch
-    bundleID="audio.existential.$driverVartiantName"
-    
-    # Build
-    xcodebuild \
-      -project BlackHole.xcodeproj \
-      -configuration Release \
-      -target BlackHole CONFIGURATION_BUILD_DIR=build \
-      PRODUCT_BUNDLE_IDENTIFIER=$bundleID \
-      GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS 
-      kNumber_Of_Channels='$channels' 
-      kPlugIn_BundleID=\"'$bundleID'\" 
-      kDriver_Name=\"'$driverName'\"'
-    
-    # Generate a new UUID
-    uuid=$(uuidgen)
-    awk '{sub(/e395c745-4eea-4d94-bb92-46224221047c/,"'$uuid'")}1' build/BlackHole.driver/Contents/Info.plist > Temp.plist
-    mv Temp.plist build/BlackHole.driver/Contents/Info.plist
-    
-    mkdir Installer/root
-    driverBundleName=$driverVartiantName.driver
-    mv build/BlackHole.driver Installer/root/$driverBundleName
-    rm -r build
-    
-    # Sign
-    codesign \
-      --force \
-      --deep \
-      --options runtime \
-      --sign $devTeamID \
-      Installer/root/$driverBundleName
-    
-    # Create package with pkgbuild
-    chmod 755 Installer/Scripts/preinstall
-    chmod 755 Installer/Scripts/postinstall
-    
-    pkgbuild \
-      --sign $devTeamID \
-      --root Installer/root \
-      --scripts Installer/Scripts \
-      --install-location /Library/Audio/Plug-Ins/HAL \
-      "Installer/$driverName.pkg"
-    rm -r Installer/root
-    
-    # Create installer with productbuild
-    cd Installer
-    
-    echo "<?xml version=\"1.0\" encoding='utf-8'?>
-    <installer-gui-script minSpecVersion='2'>
-        <title>$driverName: Audio Loopback Driver ($ch) $version</title>
-        <welcome file='welcome.html'/>
-        <license file='../LICENSE'/>
-        <conclusion file='conclusion.html'/>
-        <domains enable_anywhere='false' enable_currentUserHome='false' enable_localSystem='true'/>
-        <pkg-ref id=\"$bundleID\"/>
-        <options customize='never' require-scripts='false' hostArchitectures='x86_64,arm64'/>
-        <volume-check>
-            <allowed-os-versions>
-                <os-version min='10.10'/>
-            </allowed-os-versions>
-        </volume-check>
-        <choices-outline>
-            <line choice=\"$bundleID\"/>
-        </choices-outline>
-        <choice id=\"$bundleID\" visible='true' title=\"$driverName $ch\" start_selected='true'>
-            <pkg-ref id=\"$bundleID\"/>
-        </choice>
-        <pkg-ref id=\"$bundleID\" version=\"$version\" onConclusion='RequireRestart'>$driverName.pkg</pkg-ref>
-    </installer-gui-script>" >> distribution.xml
-    
-    # Build
-    installerPkgName="$driverVartiantName-$version.pkg"
-    productbuild \
-      --sign $devTeamID \
-      --distribution distribution.xml \
-      --resources . \
-      --package-path $driverName.pkg $installerPkgName
-    rm distribution.xml
-    rm -f $driverName.pkg
-    
-    # Notarize and Staple
-    if [ "$notarize" = true ]; then
-        xcrun \
-          notarytool submit $installerPkgName \
-          --team-id $devTeamID \
-          --progress \
-          --wait \
-          --keychain-profile $notarizeProfile
-        
-        xcrun stapler staple $installerPkgName
-    fi
+  for instance in $(seq 0 3); do
+      # Env
+      ch=$channels"ch"
+      suffix=
+      if [[ $instance -gt 0 ]]; then
+        suffix="_${instance}"
+      fi
+      driverVariantName=$driverName$ch$suffix
+      bundleID="audio.existential.$driverVariantName"
+      
+      # Build
+      xcodebuild \
+        -project BlackHole.xcodeproj \
+        -configuration Release \
+        -target BlackHole CONFIGURATION_BUILD_DIR=build \
+        PRODUCT_BUNDLE_IDENTIFIER=$bundleID \
+        GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS 
+        kNumber_Of_Channels='$channels' 
+        kPlugIn_BundleID=\"'$bundleID'\" 
+        kDriver_Name=\"'$driverName$suffix'\"'
+      
+      # Generate a new UUID
+      uuid=$(uuidgen)
+      awk '{sub(/e395c745-4eea-4d94-bb92-46224221047c/,"'$uuid'")}1' build/BlackHole.driver/Contents/Info.plist > Temp.plist
+      mv Temp.plist build/BlackHole.driver/Contents/Info.plist
+      
+      mkdir Installer/root
+      driverBundleName=$driverVariantName.driver
+      mv build/BlackHole.driver Installer/root/$driverBundleName
+      rm -r build
+      
+      # Sign
+      codesign \
+        --force \
+        --deep \
+        --options runtime \
+        --sign $devTeamID \
+        Installer/root/$driverBundleName
+      
+      # Create package with pkgbuild
+      chmod 755 Installer/Scripts/preinstall
+      chmod 755 Installer/Scripts/postinstall
+      
+      pkgbuild \
+        --sign $devTeamID \
+        --root Installer/root \
+        --scripts Installer/Scripts \
+        --install-location /Library/Audio/Plug-Ins/HAL \
+        "Installer/$driverName.pkg"
+      rm -r Installer/root
+      
+      # Create installer with productbuild
+      cd Installer
+      
+      echo "<?xml version=\"1.0\" encoding='utf-8'?>
+      <installer-gui-script minSpecVersion='2'>
+          <title>$driverName: Audio Loopback Driver ($ch) $version</title>
+          <welcome file='welcome.html'/>
+          <license file='../LICENSE'/>
+          <conclusion file='conclusion.html'/>
+          <domains enable_anywhere='false' enable_currentUserHome='false' enable_localSystem='true'/>
+          <pkg-ref id=\"$bundleID\"/>
+          <options customize='never' require-scripts='false' hostArchitectures='x86_64,arm64'/>
+          <volume-check>
+              <allowed-os-versions>
+                  <os-version min='10.10'/>
+              </allowed-os-versions>
+          </volume-check>
+          <choices-outline>
+              <line choice=\"$bundleID\"/>
+          </choices-outline>
+          <choice id=\"$bundleID\" visible='true' title=\"$driverName $ch\" start_selected='true'>
+              <pkg-ref id=\"$bundleID\"/>
+          </choice>
+          <pkg-ref id=\"$bundleID\" version=\"$version\" onConclusion='RequireRestart'>$driverName.pkg</pkg-ref>
+      </installer-gui-script>" >> distribution.xml
+      
+      # Build
+      installerPkgName="$driverVariantName-$version.pkg"
+      productbuild \
+         --sign $devTeamID \
+        --distribution distribution.xml \
+        --resources . \
+        --package-path $driverName.pkg $installerPkgName
+      rm distribution.xml
+      rm -f $driverName.pkg
+      
+      # Notarize and Staple
+      if [ "$notarize" = true ]; then
+          xcrun \
+            notarytool submit $installerPkgName \
+            --team-id $devTeamID \
+            --progress \
+            --wait \
+            --keychain-profile $notarizeProfile
+          
+          xcrun stapler staple $installerPkgName
+      fi
 
-    cd ..
+      cd ..
+  done
 done


### PR DESCRIPTION
Simplifies https://github.com/ExistentialAudio/BlackHole/wiki/Running-Multiple-BlackHole-Drivers by allowing users to download pre-signed packages if they need multiple drivers at a particular channel number.

4 is arbitrary, but allows one to have two apps, each with a virtual input and output.

Inspired by https://github.com/ExistentialAudio/BlackHole/discussions/472

While I'm here, fix a typo.

(Note for reviewers: Most of the diff here is indentation change; I believe github lets you hide whitespace-only changes, though)