### PR TITLE
Honour the documented kLatency_Frame_Size build-time override

### DIFF
--- a/BlackHole/BlackHole.c
+++ b/BlackHole/BlackHole.c
@@ -232,7 +232,9 @@ struct ObjectInfo {
 #define                             kManufacturer_Name                  "Existential Audio Inc."
 #endif
 
+#ifndef kLatency_Frame_Size
 #define                             kLatency_Frame_Size                 0
+#endif
 
 #ifndef kNumber_Of_Channels
 #define                             kNumber_Of_Channels                 2


### PR DESCRIPTION
I was resolving a chirping in audio recordings which turned out to be an ffmpeg issue rather than BlackHole 👍

While in the code I noticed a minor inconsistency that you might want to look at.

First time contributor for this project so let me know if you need anything else.

## Problem

`kLatency_Frame_Size` is defined unconditionally, unlike every other customisable constant in the same block. Any `GCC_PREPROCESSOR_DEFINITIONS` override is therefore discarded silently — the file's own definition always wins — so the customisation documented in `README.md` cannot take effect.

| Constant | `#ifndef` guard |
| --- | --- |
| `kManufacturer_Name` | yes |
| `kLatency_Frame_Size` | **no** |
| `kNumber_Of_Channels` | yes |
| `kEnableVolumeControl` | yes |

## Change

Add the missing guard. Two added lines, nothing modified or removed. The default stays `0`.

## Verification

Ring buffer allocation size read from the compiled binary (`kRing_Buffer_Frame_Size * kNumber_Of_Channels`):

| Build | Constant | Result |
| --- | --- | --- |
| `master`, unpatched | `0x20000` | baseline |
| Patched, no override | `0x20000` | identical binary — matching MD5 across 8,864 disassembled instructions, both architectures |
| Patched, `-D kLatency_Frame_Size=512` | `0x20400` | override now honoured |

Stock builds are therefore bit-for-bit unaffected; only builds that explicitly pass the constant see any change.
