### PR TITLE
Report the size written for kAudioBoxPropertyBoxUID

### DIFF
--- a/BlackHole/BlackHole.c
+++ b/BlackHole/BlackHole.c
@@ -1956,6 +1956,7 @@ static OSStatus	BlackHole_GetBoxPropertyData(AudioServerPlugInDriverRef inDriver
 			FailWithAction(inDataSize < sizeof(CFStringRef), theAnswer = kAudioHardwareBadPropertySizeError, Done, "BlackHole_GetBoxPropertyData: not enough space for the return value of kAudioObjectPropertyManufacturer for the box");
 
 			*((CFStringRef*)outData) = get_box_uid();
+			*outDataSize = sizeof(CFStringRef);
 			break;
 			
 		case kAudioBoxPropertyTransportType:


### PR DESCRIPTION
### The bug

`BlackHole_GetBoxPropertyData` handles `kAudioBoxPropertyBoxUID` like this:

```c
case kAudioBoxPropertyBoxUID:
    //	Boxes have UIDs the same as devices
    FailWithAction(inDataSize < sizeof(CFStringRef), ...);

    *((CFStringRef*)outData) = get_box_uid();
    break;
```

It writes the value and returns success, but it is the only case in that switch which never assigns `*outDataSize`. The function only null-checks that pointer, it does not initialise it, so the caller is left holding whatever it passed in.

Calling the driver directly with a sentinel in `outDataSize`, with a case that does set it for contrast:

```
BoxUID   st=0  outDataSize=0xABCDEF01 (expect 0x00000008)  wroteString=yes
Serial#  outDataSize=0x00000008  (a case that sets it, for contrast)
```

`BlackHole_GetBoxPropertyDataSize` already answers `sizeof(CFStringRef)` for this same selector, so the two entry points disagree with each other. Apple's reference plug-ins set the size on every path that writes a value.

### The change

One line. With it applied, the sentinel is replaced by 8.

### How I checked it

I compiled `BlackHole.c` standalone the same way `BlackHoleTests/main.c` does — `#define`ing the device flags and `#include`ing the .c — and called `BlackHole_GetPropertyData` directly, before and after the change.

Two things I noticed while doing that, which are not part of this PR but may be worth knowing:

**`BlackHoleTests/main.c` does not pass on `master`.** It asserts the owned-object list sizes are 12, but the driver now reports 20 for the global scope and 16 for output, so it stops at the first assertion:

```
Assertion failed: (size == 12), function main, file main.c, line 33.
```

That is presumably just the object list having grown since the test was written. It also does `data = calloc(size, 1)` where `size` is 0 and then reads `data[0]`, which reads a zero-byte allocation. Happy to send a separate PR updating the expectations and that read if it would be useful — I left it alone here to keep this change to one line.

### Disclosure

This was written with Claude Code assisting, under my direction, and the commit carries an `Assisted-By` trailer. I reviewed and verified the change myself; the before/after output above is from my own machine. I did not find an AI policy in the repo — happy to follow one if you have a preference, or to close this if you would rather not take agent-assisted patches.

X: manuaudiomix
