### PR TITLE
Make the shared IO state in DoIOOperation atomic

### DIFF
--- a/BlackHole/BlackHole.c
+++ b/BlackHole/BlackHole.c
@@ -16,6 +16,7 @@
 #include <dispatch/dispatch.h>
 #include <mach/mach_time.h>
 #include <pthread.h>
+#include <stdatomic.h>
 #include <stdint.h>
 #include <sys/syslog.h>
 #include <Accelerate/Accelerate.h>
@@ -4546,24 +4547,28 @@ static OSStatus	BlackHole_DoIOOperation(AudioServerPlugInDriverRef inDriver, Aud
         secondPartFrameSize = inIOBufferFrameSize - firstPartFrameSize;
     }
     
-    // Keep track of last outputSampleTime and the cleared buffer status.
-    static Float64 lastOutputSampleTime = 0;
-    static Boolean isBufferClear = true;
+    //	Keep track of last outputSampleTime and the cleared buffer status. These are
+    //	shared by every IO thread: the output side writes them and the input side
+    //	reads them, and kObjectID_Device and kObjectID_Device2 each get their own IO
+    //	thread. Use relaxed atomics so the accesses are well defined without adding
+    //	any ordering cost on the realtime path.
+    static _Atomic Float64 lastOutputSampleTime = 0;
+    static _Atomic Boolean isBufferClear = true;
     
     // From BlackHole to Application
     if(inOperationID == kAudioServerPlugInIOOperationReadInput)
     {
         // If mute is one let's just fill the buffer with zeros or if there's no apps outputting audio
-        if (gMute_Master_Value || lastOutputSampleTime - inIOBufferFrameSize < inIOCycleInfo->mInputTime.mSampleTime)
+        if (gMute_Master_Value || atomic_load_explicit(&lastOutputSampleTime, memory_order_relaxed) - inIOBufferFrameSize < inIOCycleInfo->mInputTime.mSampleTime)
         {
             // Clear the ioMainBuffer
             vDSP_vclr(ioMainBuffer, 1, inIOBufferFrameSize * kNumber_Of_Channels);
             
             // Clear the ring buffer.
-            if (!isBufferClear)
+            if (!atomic_load_explicit(&isBufferClear, memory_order_relaxed))
             {
                 vDSP_vclr(gRingBuffer, 1, kRing_Buffer_Frame_Size * kNumber_Of_Channels);
-                isBufferClear = true;
+                atomic_store_explicit(&isBufferClear, true, memory_order_relaxed);
             }
         }
         else
@@ -4599,8 +4604,8 @@ static OSStatus	BlackHole_DoIOOperation(AudioServerPlugInDriverRef inDriver, Aud
         memcpy(gRingBuffer, (Float32*)ioMainBuffer + firstPartFrameSize * kNumber_Of_Channels, secondPartFrameSize * kNumber_Of_Channels * sizeof(Float32));
         
         // Save the last output time.
-        lastOutputSampleTime = inIOCycleInfo->mOutputTime.mSampleTime + inIOBufferFrameSize;
-        isBufferClear = false;
+        atomic_store_explicit(&lastOutputSampleTime, inIOCycleInfo->mOutputTime.mSampleTime + inIOBufferFrameSize, memory_order_relaxed);
+        atomic_store_explicit(&isBufferClear, false, memory_order_relaxed);
     }
 
 Done:


### PR DESCRIPTION
`BlackHole_DoIOOperation` keeps two pieces of cross-cycle state as function-local statics:

```c
static Float64 lastOutputSampleTime = 0;
static Boolean isBufferClear = true;
```

They are **written on the output path** and **read on the input path**, and there is no lock or atomic anywhere in that function. There is one copy shared by every caller — and since `kObjectID_Device` and `kObjectID_Device2` are separate `AudioObject`s, the HAL drives them on separate IO threads. So the accesses are unsynchronised.

The read that matters is the silence heuristic:

```c
if (gMute_Master_Value || lastOutputSampleTime - inIOBufferFrameSize < inIOCycleInfo->mInputTime.mSampleTime)
```

A stale read makes one input cycle emit silence when it should have passed audio, or pass stale ring content when it should have muted.

## What this claims, and what it doesn't

The race is visible by inspection. **I have not reproduced a user-audible fault from it, and I am not claiming it explains any particular dropout report.** On arm64 an aligned 8-byte load won't tear, so the plausible symptom is staleness for one cycle rather than corruption. Treat this as a concurrency-correctness fix, not a fix for a filed issue.

## Why relaxed atomics, and why they're free here

Relaxed atomics make the accesses well defined without buying ordering that isn't needed. On arm64 the cost is nil:

- `atomic_is_lock_free` returns 1 for both `Float64` (8 bytes) and `Boolean` (1 byte) — no lock is taken on the realtime path.
- Comparing `-O2` output for `DoIOOperation` before and after: **zero barrier instructions in either version** — no `dmb`, `ldar`, `stlr`, `ldaxr` or `stlxr`. The loads and stores compile to the same plain instructions as before.

That second point was the thing worth checking; a fix that put a lock or a barrier on the IO path would be worse than the race.

## Note

The existing comment just above the output write — *"Issue with outputting from mirrored device and main device at the same time. Not currently mixing."* — suggests the concurrent Device/Device2 case is already known to be rough. This doesn't address the mixing question, only the unsynchronised access.

Builds clean (`clang -std=gnu11 -Wall -Wextra`, no new warnings). I couldn't run the full Xcode build locally as it wants a signing certificate for team `Q5C99V536K`, so the driver itself is unsigned-untested here — worth a sanity check on your side before merging.
