### PR TITLE
Guard against a NULL bundle in kAudioObjectPropertyFirmwareVersion

### DIFF
--- a/BlackHole/BlackHole.c
+++ b/BlackHole/BlackHole.c
@@ -1945,8 +1945,11 @@ static OSStatus	BlackHole_GetBoxPropertyData(AudioServerPlugInDriverRef inDriver
 		case kAudioObjectPropertyFirmwareVersion:
 			//	This is the human readable firmware version of the box.
 			FailWithAction(inDataSize < sizeof(CFStringRef), theAnswer = kAudioHardwareBadPropertySizeError, Done, "BlackHole_GetBoxPropertyData: not enough space for the return value of kAudioObjectPropertyFirmwareVersion for the box");
-            CFStringRef version = (CFStringRef)CFBundleGetValueForInfoDictionaryKey(CFBundleGetBundleWithIdentifier(CFSTR(kPlugIn_BundleID)), CFSTR("CFBundleShortVersionString"));
-            CFRetain(version);
+			CFBundleRef theVersionBundle = CFBundleGetBundleWithIdentifier(CFSTR(kPlugIn_BundleID));
+			FailWithAction(theVersionBundle == NULL, theAnswer = kAudioHardwareUnspecifiedError, Done, "BlackHole_GetBoxPropertyData: could not get the plug-in bundle for kAudioObjectPropertyFirmwareVersion");
+			CFStringRef version = (CFStringRef)CFBundleGetValueForInfoDictionaryKey(theVersionBundle, CFSTR("CFBundleShortVersionString"));
+			FailWithAction(version == NULL, theAnswer = kAudioHardwareUnspecifiedError, Done, "BlackHole_GetBoxPropertyData: could not get CFBundleShortVersionString for kAudioObjectPropertyFirmwareVersion");
+			CFRetain(version);
 			*((CFStringRef*)outData) = version;
 			*outDataSize = sizeof(CFStringRef);
 			break;


### PR DESCRIPTION
### Problem

`BlackHole_GetBoxPropertyData` passes the result of `CFBundleGetBundleWithIdentifier` straight into `CFBundleGetValueForInfoDictionaryKey`, then retains it:

```
CFStringRef version = (CFStringRef)CFBundleGetValueForInfoDictionaryKey(CFBundleGetBundleWithIdentifier(CFSTR(kPlugIn_BundleID)), CFSTR("CFBundleShortVersionString"));
CFRetain(version);
```

Either call can return `NULL` — `CFBundleGetBundleWithIdentifier` only finds bundles already loaded and registered, and the Info.plist key could be missing or renamed.
`CFRetain(NULL)` crashes, and because this runs inside `coreaudiod` it drops all audio on the machine until launchd restarts it.

Audio MIDI Setup reads the firmware version on the normal user path, so this would surface immediately rather than in some obscure state.

### Fix

Check both results and return `kAudioHardwareUnspecifiedError`, mirroring how `kAudioDevicePropertyIcon` already guards the same bundle lookup.

### Testing

Built and installed all four channel-count variants of a downstream fork on macOS 26.5 (Apple Silicon); the firmware version reports correctly and the guard doesn't fire on the normal path.