### PR TITLE
Fix two installer script bugs

### DIFF
--- a/Installer/create_installer.sh
+++ b/Installer/create_installer.sh
@@ -67,13 +67,13 @@ for channels in 2 16 64 128 256; do
       Installer/root/$driverBundleName
     
     # Create package with pkgbuild
-    chmod 755 Installer/Scripts/preinstall
-    chmod 755 Installer/Scripts/postinstall
+    chmod 755 Installer/scripts/preinstall
+    chmod 755 Installer/scripts/postinstall
     
     pkgbuild \
       --sign $devTeamID \
       --root Installer/root \
-      --scripts Installer/Scripts \
+      --scripts Installer/scripts \
       --install-location /Library/Audio/Plug-Ins/HAL \
       "Installer/$driverName.pkg"
     rm -r Installer/root

--- a/Uninstaller/create_uninstaller.sh
+++ b/Uninstaller/create_uninstaller.sh
@@ -38,7 +38,7 @@ fi' > Uninstaller/Scripts/postinstall
     if [ "$notarize" = true ]; then
 
         # Submit the package for notarization and capture output, also displaying it simultaneously
-        output=$(xcrun notarytool submit "$packageName" --progress --wait --keychain-profile "notarize" 2>&1 | tee /dev/tty)
+        output=$(xcrun notarytool submit "$packageName" --progress --wait --keychain-profile "$notarizeProfile" 2>&1 | tee /dev/tty)
 
         # Extract the submission ID
         submission_id=$(echo "$output" | grep -o -E 'id: [a-f0-9-]+' | awk '{print $2}' | head -n1)
@@ -54,7 +54,7 @@ fi' > Uninstaller/Scripts/postinstall
 
           # Fetch and display notarization logs
           echo -e "\nFetching logs for submission ID: $submission_id"
-          xcrun notarytool log --keychain-profile "notarize" "$submission_id"
+          xcrun notarytool log --keychain-profile "$notarizeProfile" "$submission_id"
           exit 1
         else
           echo "Notarization submitted successfully ✅"


### PR DESCRIPTION
Two independent bugs in the release scripts, both cases of documented behaviour silently not working.

- `create_installer.sh` refers to `Installer/Scripts` (capital 'S'), but the directory is `Installer/scripts` (lower case 's')

Three occurrences (lines 70, 71, 76). This works on a case-insensitive filesystem, which is the macOS default, so it goes unnoticed — but on a case-sensitive volume the `chmod` calls fail and `pkgbuild --scripts` finds nothing, producing packages with no pre/postinstall scripts. `Uninstaller/Scripts` is capitalised, which is likely where the confusion came from.

- `create_uninstaller.sh` defines `notarizeProfile` and then does not use it

Line 6 sets it with a comment telling you to replace it with your own profile name, but both `notarytool` call sites (lines 41, 57) hardcode `"notarize"`. Anyone whose keychain profile is named anything else can't notarize, and the failure looks like a credentials problem rather than a script bug.

Happy to split these into separate PRs if you'd prefer.